### PR TITLE
the comma version of the except statement is deprecated

### DIFF
--- a/ovrsdk/windows/wrapper.py
+++ b/ovrsdk/windows/wrapper.py
@@ -370,7 +370,7 @@ class LibraryLoader(object):
                 return ctypes.CDLL(path, ctypes.RTLD_GLOBAL)
             else:
                 return ctypes.cdll.LoadLibrary(path)
-        except OSError,e:
+        except OSError as e:
             raise ImportError(e)
 
     def getpaths(self,libname):


### PR DESCRIPTION
In python 3.3.3 a syntax error is produced by the except statement with a comma.
Solution: use "as" instead.
(This also causes trouble in pip install command under 3.3.3, see also stackoverflow.com/questions/20517785/python-except-oserror-e-no-longer-working-in-3-3-3)
